### PR TITLE
[#21] Add use of context.Background() for godo

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -152,7 +152,7 @@ func CreateCluster(client godo.Client, cmd *cobra.Command, clusterName string) {
 		PrivateNetworking: true,
 	}
 
-	droplet, _, err := client.Droplets.CreateMultiple(createRequest)
+	droplet, _, err := client.Droplets.CreateMultiple(ctx, createRequest)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/cmd/droplet.go
+++ b/cmd/droplet.go
@@ -137,7 +137,7 @@ func ListDroplets(client godo.Client) []godo.Droplet {
 		Page:    1,
 		PerPage: 25,
 	}
-	droplets, _, _ := client.Droplets.List(opt)
+	droplets, _, _ := client.Droplets.List(ctx, opt)
 	return droplets
 }
 
@@ -164,7 +164,7 @@ func CreateDroplet(client godo.Client, cmd *cobra.Command) {
 		os.Exit(-1)
 	}
 
-	droplet, _, err := client.Droplets.Create(createRequest)
+	droplet, _, err := client.Droplets.Create(ctx, createRequest)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
@@ -173,7 +173,7 @@ func CreateDroplet(client godo.Client, cmd *cobra.Command) {
 }
 
 func DeleteDroplet(client godo.Client, id int) error {
-	_, err := client.Droplets.Delete(id)
+	_, err := client.Droplets.Delete(ctx, id)
 	return err
 }
 
@@ -183,6 +183,6 @@ func GetDroplet(client godo.Client, name string) (*godo.Droplet, error) {
 		return nil, err
 	}
 
-	droplet, _, err := client.Droplets.Get(id)
+	droplet, _, err := client.Droplets.Get(ctx, id)
 	return droplet, err
 }

--- a/main.go
+++ b/main.go
@@ -14,7 +14,12 @@
 
 package main
 
-import "github.com/jconard3/docore/cmd"
+import (
+	"context"
+	"github.com/jconard3/docore/cmd"
+)
+
+var ctx = context.Background()
 
 func main() {
 	cmd.Execute()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,7 +16,7 @@ func NameToID(client godo.Client, droplet_name string) (int, error) {
 		Page:    1,
 		PerPage: 25,
 	}
-	droplets, _, err := client.Droplets.List(opt)
+	droplets, _, err := client.Droplets.List(ctx, opt)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
godo added context.Context to all of their requests. I believe they're getting
the actual desired context from the API but it looks like we can work around
the issue until there's a method similar to the Get(context.Context) from godo
available in docore. Fixes #21 