### PR TITLE
Revert "Fix import namespace for local packages"

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -20,10 +20,9 @@ import (
 	"os"
 	"strings"
 
-	"../client"
-	"../utils"
-
 	"github.com/digitalocean/godo"
+	"github.com/jconard3/docore/client"
+	"github.com/jconard3/docore/utils"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/droplet.go
+++ b/cmd/droplet.go
@@ -18,10 +18,9 @@ import (
 	"fmt"
 	"os"
 
-	"../client"
-	"../utils"
-
 	"github.com/digitalocean/godo"
+	"github.com/jconard3/docore/client"
+	"github.com/jconard3/docore/utils"
 	"github.com/spf13/cobra"
 )
 

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	"./cmd"
 	"context"
+	"github.com/jconard3/docore/cmd"
 )
 
 var ctx = context.Background()


### PR DESCRIPTION
Reverts jconard3/docore#23

Causing build errors 

https://circleci.com/gh/jconard3/docore/1

`can't load package: /home/ubuntu/.go_project/src/github.com/jconard3/docore/main.go:18:2: local import "./cmd" in non-local package`