### PR TITLE
Droplet subcommand improvements

### DIFF
--- a/cmd/droplet.go
+++ b/cmd/droplet.go
@@ -124,8 +124,8 @@ var dropletDeleteCmd = &cobra.Command{
 }
 
 var dropletInfoCmd = &cobra.Command{
-	Use:   "info <droplet_name>",
-	Short: "Get details of a droplet",
+	Use:   "info [droplet1 droplet2...]",
+	Short: "Get details of one or more droplets",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			fmt.Println("No name specified for retrieving droplet. Aborting.")
@@ -139,19 +139,21 @@ var dropletInfoCmd = &cobra.Command{
 			os.Exit(-1)
 		}
 
-		droplet, err := GetDroplet(c, args[0])
-		if err != nil {
-			fmt.Println(err)
-			fmt.Println("error retrieving droplet. Aborting")
-			os.Exit(-1)
-		}
+		for _, n := range args {
+			droplet, err := GetDroplet(c, n)
+			if err != nil {
+				fmt.Println(err)
+				fmt.Println("error retrieving droplet %s. Aborting", n)
+				os.Exit(-1)
+			}
 
-		if strings.Compare("true", cmd.Flag("verbose").Value.String()) == 0 {
-			fmt.Println(droplet)
-		} else {
-			fmt.Println("Name: \t", droplet.Name)
-			fmt.Println("IP: \t", droplet.Networks.V4[0].IPAddress)
-			fmt.Println("OS: \t", droplet.Image.Slug)
+			if strings.Compare("true", cmd.Flag("verbose").Value.String()) == 0 {
+				fmt.Println(droplet)
+			} else {
+				fmt.Println("Name: \t", droplet.Name)
+				fmt.Println("IP: \t", droplet.Networks.V4[0].IPAddress)
+				fmt.Println("OS: \t", droplet.Image.Slug)
+			}
 		}
 	},
 }

--- a/cmd/droplet.go
+++ b/cmd/droplet.go
@@ -69,8 +69,8 @@ var dropletListCmd = &cobra.Command{
 }
 
 var dropletCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a droplet",
+	Use:   "create [droplet1 droplet2...]",
+	Short: "Create one or more droplets",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			fmt.Println("No name specified for creating droplet. Aborting.")
@@ -84,7 +84,9 @@ var dropletCreateCmd = &cobra.Command{
 			os.Exit(-1)
 		}
 
-		CreateDroplet(c, cmd, args[0])
+		for _, n := range args {
+			CreateDroplet(c, cmd, n)
+		}
 	},
 }
 

--- a/cmd/droplet.go
+++ b/cmd/droplet.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/jconard3/docore/client"
@@ -34,9 +35,9 @@ func init() {
 	dropletCreateCmd.Flags().StringP("image", "i", "coreos-stable", "Image of droplet to be created")
 
 	dropletCmd.AddCommand(dropletDeleteCmd)
-	dropletDeleteCmd.Flags().StringP("name", "n", "", "Name of droplet to be created. Required - no default")
 
-	dropletCmd.AddCommand(dropletGetCmd)
+	dropletCmd.AddCommand(dropletInfoCmd)
+	dropletInfoCmd.Flags().BoolP("verbose", "v", false, "Display full droplet details")
 }
 
 var dropletCmd = &cobra.Command{
@@ -122,9 +123,9 @@ var dropletDeleteCmd = &cobra.Command{
 	},
 }
 
-var dropletGetCmd = &cobra.Command{
-	Use:   "get <droplet_name>",
-	Short: "Get full details of a droplet",
+var dropletInfoCmd = &cobra.Command{
+	Use:   "info <droplet_name>",
+	Short: "Get details of a droplet",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			fmt.Println("No name specified for retrieving droplet. Aborting.")
@@ -144,7 +145,14 @@ var dropletGetCmd = &cobra.Command{
 			fmt.Println("error retrieving droplet. Aborting")
 			os.Exit(-1)
 		}
-		fmt.Println(droplet)
+
+		if strings.Compare("true", cmd.Flag("verbose").Value.String()) == 0 {
+			fmt.Println(droplet)
+		} else {
+			fmt.Println("Name: \t", droplet.Name)
+			fmt.Println("IP: \t", droplet.Networks.V4[0].IPAddress)
+			fmt.Println("OS: \t", droplet.Image.Slug)
+		}
 	},
 }
 

--- a/cmd/droplet.go
+++ b/cmd/droplet.go
@@ -29,7 +29,6 @@ func init() {
 	dropletCmd.AddCommand(dropletListCmd)
 
 	dropletCmd.AddCommand(dropletCreateCmd)
-	dropletCreateCmd.Flags().StringP("name", "n", "", "Name of droplet to be created. Required - no default")
 	dropletCreateCmd.Flags().StringP("region", "r", "nyc1", "Region of droplet to be created")
 	dropletCreateCmd.Flags().StringP("size", "s", "512mb", "RAM size of droplet to be created")
 	dropletCreateCmd.Flags().StringP("image", "i", "coreos-stable", "Image of droplet to be created")
@@ -38,7 +37,6 @@ func init() {
 	dropletDeleteCmd.Flags().StringP("name", "n", "", "Name of droplet to be created. Required - no default")
 
 	dropletCmd.AddCommand(dropletGetCmd)
-	dropletGetCmd.Flags().StringP("name", "n", "", "Name of droplet to get retrieved. Required - no default")
 }
 
 var dropletCmd = &cobra.Command{


### PR DESCRIPTION
1. Renamed 'get' to 'info'
2. 'info' default prints more sane and human readable results. Added '--verbose' option for full output
2. Changed '--name' flag to a command line argument
3. 'create', 'info', 'delete' accept multiple droplet names via command line arguments